### PR TITLE
Fix scroll wheel on Dark Core RGB Pro

### DIFF
--- a/src/daemon/keymap.c
+++ b/src/daemon/keymap.c
@@ -1035,7 +1035,7 @@ void corsair_bragi_mousecopy(usbdevice* kb, usbinput* input, const unsigned char
 
     // Some devices only have one byte, so set those to 8 buttons
     // We need a better way to identify this
-    if(kb->vendor == V_CORSAIR && (kb->product == P_M55_RGB_PRO || kb->product == P_DARK_CORE_RGB_PRO_SE || kb->product == P_DARK_CORE_RGB_PRO_SE_WL || kb->product == P_HARPOON_WL_U))
+    if(kb->vendor == V_CORSAIR && (kb->product == P_M55_RGB_PRO || kb->product == P_DARK_CORE_RGB_PRO_SE || kb->product == P_DARK_CORE_RGB_PRO_SE_WL || kb->product == P_DARK_CORE_RGB_PRO || kb->product == P_DARK_CORE_RGB_PRO_WL || kb->product == P_HARPOON_WL_U))
         buttons = BRAGI_ONE_BYTE_MOUSE_BUTTONS;
 
     // Pick the appropriate LUT. We can't patch the keymap as that will break standard HID input.


### PR DESCRIPTION
I built your fork, but I noticed my scroll wheel stops working properly while ckb-next is running. Scroll down was switching to the Sniper DPI setting and scroll up was going back to normal DPI. I tracked down this line which fixes the issue.